### PR TITLE
fix: 플레이어의 최소속도를 기본속도와 같게 조정

### DIFF
--- a/Assets/Scripts/GameScene/PlayerController.cs
+++ b/Assets/Scripts/GameScene/PlayerController.cs
@@ -10,7 +10,7 @@ public class PlayerController : MonoBehaviour
     [SerializeField] private float maxHoldTime = 1f;
     [SerializeField] private float minHoldTime = 0.2f;
     [SerializeField] private Animator playerAnimator;
-    [SerializeField] private const float MinMoveSpeed = 1.0f;
+    [SerializeField] private const float MinMoveSpeed = 5f;
     [SerializeField] private int health = 100;
     public int Health => health;
     [SerializeField] private int maxHealth = 100;


### PR DESCRIPTION
- 속도 저하 아이템을 먹었을 시 못 넘어가는 장애물이 발생할 수 있으므로 최소속도를 기본속도와 같게 만들어 모든 장애물을 통과할 수 있도록 변경